### PR TITLE
build(postcss): correct postcss implementation

### DIFF
--- a/config/nuxt/build.ts
+++ b/config/nuxt/build.ts
@@ -1,1 +1,5 @@
-export default {}
+import postcss from './postcss'
+
+export default {
+  postcss
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,6 @@
 import { defineNuxtConfig } from 'nuxt'
 import components from './config/nuxt/components'
 import build from './config/nuxt/build'
-import postcss from './config/nuxt/build'
 import plugins from './config/nuxt/plugins'
 import hooks from './config/nuxt/hooks'
 import { privateRuntimeConfig, publicRuntimeConfig } from './config/nuxt/runtimeConfig'
@@ -24,7 +23,6 @@ export default defineNuxtConfig({
   ],
 
   build,
-  postcss,
 
   plugins,
 


### PR DESCRIPTION
Had issues with configuring postCSS, while trying to diagnose/fix I looked up the documentation and it looks like it should be part of the build process. 

This PR moves the postCSS config (`postcss.ts`) into the build config (`build.ts`).

[postCSS Documentation ](https://nuxtjs.org/docs/configuration-glossary/configuration-build#postcss) 